### PR TITLE
Enable grouping separators for numeric formatters

### DIFF
--- a/LoanCalculator/ContentView.swift
+++ b/LoanCalculator/ContentView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var residentialParameters = LoanParameters(
+        loanAmount: 450_000,
+        interestRate: 5.75,
+        termYears: 30,
+        paymentsPerYear: .monthly
+    )
+    @State private var commercialParameters = LoanParameters(
+        loanAmount: 750_000,
+        interestRate: 6.5,
+        termYears: 20,
+        paymentsPerYear: .monthly
+    )
+    @State private var vehicleParameters = LoanParameters(
+        loanAmount: 45_000,
+        interestRate: 7.25,
+        termYears: 6,
+        paymentsPerYear: .monthly
+    )
+
+    var body: some View {
+        TabView {
+            LoanCalculatorView(title: "Residential Loan", description: "Calculate payments for a residential mortgage.", parameters: $residentialParameters)
+                .tabItem {
+                    Label("Residential", systemImage: "house.fill")
+                }
+
+            LoanCalculatorView(title: "Commercial Loan", description: "Estimate repayments on a commercial property loan.", parameters: $commercialParameters)
+                .tabItem {
+                    Label("Commercial", systemImage: "building.2.fill")
+                }
+
+            LoanCalculatorView(title: "Vehicle Loan", description: "Plan out payments on a vehicle purchase.", parameters: $vehicleParameters)
+                .tabItem {
+                    Label("Vehicle", systemImage: "car.fill")
+                }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/LoanCalculator/LoanCalculatorApp.swift
+++ b/LoanCalculator/LoanCalculatorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LoanCalculatorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/LoanCalculator/Models/LoanCalculator.swift
+++ b/LoanCalculator/Models/LoanCalculator.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct LoanResult: Equatable {
+    let periodicPayment: Double
+    let totalInterest: Double
+    let totalPaid: Double
+    let schedule: [AmortizationPayment]
+}
+
+struct AmortizationPayment: Identifiable, Equatable {
+    let id: Int
+    let paymentNumber: Int
+    let paymentAmount: Double
+    let interestPaid: Double
+    let principalPaid: Double
+    let remainingBalance: Double
+}
+
+enum LoanCalculator {
+    static func calculate(for parameters: LoanParameters) -> LoanResult {
+        let principal = max(parameters.loanAmount, 0)
+        let paymentsPerYear = Double(parameters.paymentsPerYear.rawValue)
+        let numberOfPayments = Int((parameters.termYears * paymentsPerYear).rounded())
+
+        guard numberOfPayments > 0 else {
+            return LoanResult(
+                periodicPayment: 0,
+                totalInterest: 0,
+                totalPaid: 0,
+                schedule: []
+            )
+        }
+
+        let ratePerPeriod = (parameters.interestRate / 100) / paymentsPerYear
+        let paymentAmount: Double
+
+        if ratePerPeriod.isZero {
+            paymentAmount = principal / Double(numberOfPayments)
+        } else {
+            let factor = pow(1 + ratePerPeriod, Double(numberOfPayments))
+            paymentAmount = principal * (ratePerPeriod * factor) / (factor - 1)
+        }
+
+        var remainingBalance = principal
+        var schedule: [AmortizationPayment] = []
+        var totalInterest: Double = 0
+        var totalPaid: Double = 0
+
+        for paymentNumber in 1...numberOfPayments {
+            let interestPayment = remainingBalance * ratePerPeriod
+            var principalPayment = paymentAmount - interestPayment
+            principalPayment = min(max(principalPayment, 0), remainingBalance)
+
+            if paymentNumber == numberOfPayments {
+                principalPayment = remainingBalance
+            }
+
+            let actualPayment = principalPayment + max(interestPayment, 0)
+
+            remainingBalance -= principalPayment
+            remainingBalance = max(remainingBalance, 0)
+
+            totalInterest += max(interestPayment, 0)
+            totalPaid += actualPayment
+
+            let amortizationPayment = AmortizationPayment(
+                id: paymentNumber,
+                paymentNumber: paymentNumber,
+                paymentAmount: actualPayment,
+                interestPaid: max(interestPayment, 0),
+                principalPaid: principalPayment,
+                remainingBalance: remainingBalance
+            )
+            schedule.append(amortizationPayment)
+        }
+
+        return LoanResult(
+            periodicPayment: paymentAmount,
+            totalInterest: totalInterest,
+            totalPaid: totalPaid,
+            schedule: schedule
+        )
+    }
+}

--- a/LoanCalculator/Models/LoanParameters.swift
+++ b/LoanCalculator/Models/LoanParameters.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct LoanParameters: Equatable {
+    var loanAmount: Double
+    var interestRate: Double
+    var termYears: Double
+    var paymentsPerYear: PaymentFrequency
+
+    init(
+        loanAmount: Double = 350_000,
+        interestRate: Double = 5.5,
+        termYears: Double = 30,
+        paymentsPerYear: PaymentFrequency = .monthly
+    ) {
+        self.loanAmount = loanAmount
+        self.interestRate = interestRate
+        self.termYears = termYears
+        self.paymentsPerYear = paymentsPerYear
+    }
+}
+
+enum PaymentFrequency: Int, CaseIterable, Identifiable, Codable {
+    case monthly = 12
+    case biWeekly = 26
+    case weekly = 52
+
+    var id: Int { rawValue }
+
+    var label: String {
+        switch self {
+        case .monthly: return "Monthly"
+        case .biWeekly: return "Bi-Weekly"
+        case .weekly: return "Weekly"
+        }
+    }
+}

--- a/LoanCalculator/Utilities/Formatters.swift
+++ b/LoanCalculator/Utilities/Formatters.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum Formatters {
+    static let currency: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.maximumFractionDigits = 2
+        formatter.usesGroupingSeparator = true
+        return formatter
+    }()
+
+    static let percent: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 3
+        formatter.usesGroupingSeparator = true
+        return formatter
+    }()
+}

--- a/LoanCalculator/Views/CurrencyTextField.swift
+++ b/LoanCalculator/Views/CurrencyTextField.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct CurrencyTextField: View {
+    private let title: String
+    @Binding private var value: Double
+
+    init(_ title: String, value: Binding<Double>) {
+        self.title = title
+        self._value = value
+    }
+
+    var body: some View {
+        TextField(title, value: $value, formatter: Formatters.currency)
+    }
+}

--- a/LoanCalculator/Views/LoanBreakdownView.swift
+++ b/LoanCalculator/Views/LoanBreakdownView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct LoanBreakdownView: View {
+    let result: LoanResult
+    let parameters: LoanParameters
+
+    private var totalPrincipal: Double { parameters.loanAmount }
+    private var interestShare: Double {
+        guard result.totalPaid > 0 else { return 0 }
+        return result.totalInterest / result.totalPaid
+    }
+
+    private var firstPayments: [AmortizationPayment] {
+        Array(result.schedule.prefix(3))
+    }
+
+    private var finalPayment: AmortizationPayment? {
+        result.schedule.last
+    }
+
+    private var totalPaidForProgress: Double {
+        max(result.totalPaid, 1)
+    }
+
+    private var interestProgress: Double {
+        min(result.totalInterest, totalPaidForProgress)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ProgressView(value: interestProgress, total: totalPaidForProgress) {
+                Text("Interest vs principal")
+                    .font(.headline)
+            } currentValueLabel: {
+                Text(interestShare.formatted(.percent.precision(.fractionLength(0...1))))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+
+            LabeledContent("Principal", value: totalPrincipal, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            LabeledContent("Interest", value: result.totalInterest, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            LabeledContent("Total paid", value: result.totalPaid, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+
+            if !firstPayments.isEmpty {
+                DisclosureGroup("First payments") {
+                    ForEach(firstPayments) { payment in
+                        PaymentRow(payment: payment)
+                    }
+                }
+            }
+
+            if let finalPayment {
+                DisclosureGroup("Final payment") {
+                    PaymentRow(payment: finalPayment)
+                }
+            }
+        }
+    }
+}
+
+private struct PaymentRow: View {
+    let payment: AmortizationPayment
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Payment #\(payment.paymentNumber)")
+                .font(.headline)
+
+            HStack {
+                Label("Principal", systemImage: "dollarsign.circle")
+                Spacer()
+                Text(payment.principalPaid, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            }
+            .font(.subheadline)
+
+            HStack {
+                Label("Interest", systemImage: "percent")
+                Spacer()
+                Text(payment.interestPaid, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            }
+            .font(.subheadline)
+
+            HStack {
+                Label("Balance", systemImage: "chart.line.downtrend.xyaxis")
+                Spacer()
+                Text(payment.remainingBalance, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            }
+            .font(.subheadline)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct LoanBreakdownView_Previews: PreviewProvider {
+    static var previews: some View {
+        let parameters = LoanParameters(loanAmount: 300_000, interestRate: 5.5, termYears: 30, paymentsPerYear: .monthly)
+        let result = LoanCalculator.calculate(for: parameters)
+
+        Form {
+            Section {
+                LoanBreakdownView(result: result, parameters: parameters)
+            }
+        }
+    }
+}

--- a/LoanCalculator/Views/LoanCalculatorView.swift
+++ b/LoanCalculator/Views/LoanCalculatorView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct LoanCalculatorView: View {
+    let title: String
+    let description: String
+    @Binding var parameters: LoanParameters
+
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case amount, rate, years
+    }
+
+    private var result: LoanResult {
+        LoanCalculator.calculate(for: parameters)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Overview"), footer: Text(description)) {
+                    LabeledContent("Loan type", value: title)
+                    LoanMetricsSummary(result: result)
+                }
+
+                Section("Loan details") {
+                    CurrencyTextField("Loan amount", value: $parameters.loanAmount)
+                        .focused($focusedField, equals: .amount)
+                        .keyboardType(.decimalPad)
+
+                    PercentageTextField("Interest rate", value: $parameters.interestRate)
+                        .focused($focusedField, equals: .rate)
+                        .keyboardType(.decimalPad)
+
+                    Stepper(value: $parameters.termYears, in: 1...40, step: 1) {
+                        Text("Term: \(parameters.termYears, specifier: "%.0f") years")
+                    }
+
+                    Picker("Payment frequency", selection: $parameters.paymentsPerYear) {
+                        ForEach(PaymentFrequency.allCases) { frequency in
+                            Text(frequency.label).tag(frequency)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("Amortization summary") {
+                    LoanBreakdownView(result: result, parameters: parameters)
+                }
+            }
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        focusedField = nil
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct LoanCalculatorView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoanCalculatorView(
+            title: "Residential Loan",
+            description: "Example",
+            parameters: .constant(LoanParameters())
+        )
+    }
+}

--- a/LoanCalculator/Views/LoanMetricsSummary.swift
+++ b/LoanCalculator/Views/LoanMetricsSummary.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct LoanMetricsSummary: View {
+    let result: LoanResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Payment", systemImage: "creditcard")
+                Spacer()
+                Text(result.periodicPayment, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                    .bold()
+            }
+
+            HStack {
+                Label("Total interest", systemImage: "chart.line.uptrend.xyaxis")
+                Spacer()
+                Text(result.totalInterest, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            }
+
+            HStack {
+                Label("Total paid", systemImage: "banknote")
+                Spacer()
+                Text(result.totalPaid, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+            }
+        }
+    }
+}
+
+struct LoanMetricsSummary_Previews: PreviewProvider {
+    static var previews: some View {
+        LoanMetricsSummary(result: LoanResult(
+            periodicPayment: 2000,
+            totalInterest: 120_000,
+            totalPaid: 470_000,
+            schedule: []
+        ))
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/LoanCalculator/Views/PercentageTextField.swift
+++ b/LoanCalculator/Views/PercentageTextField.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PercentageTextField: View {
+    private let title: String
+    @Binding private var value: Double
+
+    init(_ title: String, value: Binding<Double>) {
+        self.title = title
+        self._value = value
+    }
+
+    var body: some View {
+        HStack {
+            TextField(title, value: $value, formatter: Formatters.percent)
+            Text("%")
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# loan-calculator
+# Loan Calculator
+
 iOS app for calculating mortgage and loan repayments.
+
+## Features
+- Support for residential, commercial, and vehicle loan scenarios
+- Adjustable loan amount, interest rate, term length, and payment frequency (monthly, bi-weekly, weekly)
+- Automatic amortization calculations with a breakdown of principal vs interest
+- Quick comparison of total repayment metrics for each loan type
+
+## Getting Started
+1. Open the `LoanCalculator` directory in Xcode (File → Open…)
+2. Select *LoanCalculatorApp* as the run target
+3. Build and run the project on an iOS 17+ simulator or device
+
+The amortization logic is implemented in pure Swift and can be reused across platforms or integrated into other apps as needed.


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS application with tabs for residential, commercial, and vehicle loan calculations
- implement reusable loan calculation engine and reusable form components for currency and percentage inputs
- present amortization summaries with repayment metrics and disclosure groups for sample payments
- ensure numeric formatters use grouping separators so large values render with thousands separators

## Testing
- Not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_b_68dfb2591fe4832ca06e99849b34e94a